### PR TITLE
Fix: return the compilation exit status

### DIFF
--- a/src/main/resources/cgjavac
+++ b/src/main/resources/cgjavac
@@ -3,5 +3,8 @@
 echo "CG> redirect-streams --input err compilation"
 
 java -jar /usr/src/codingame/java-compiler/java-compiler.jar "$@"
+compilationExitCode=$?
 
 echo "CG> redirect-streams --reset --input err compilation"
+
+exit $compilationExitCode


### PR DESCRIPTION
The `cgjavac` script returns systematically 0 (the `echo` exit code). Then, it is never considered as compilation error.